### PR TITLE
Removes the svg file after it is used

### DIFF
--- a/src/notexview.cpp
+++ b/src/notexview.cpp
@@ -204,7 +204,7 @@ int NotexView::render_tex(const Glib::ustring& text, int num_rendered,
 	if (pid == 0) {
 
 		char* args[] = {(char*)"rm", (char*)"standalone.aux",
-						(char*)"standalone.pdf", (char*)"standalone.log", NULL};
+						(char*)"standalone.pdf", (char*)"standalone.log", &filename[0], NULL};
 		int exit_code = execvp(args[0], args);
 
 		return exit_code;


### PR DESCRIPTION
Closes  #8

This adds the svg file to the list of files which are removed.

The svg file name is converted to a char* with &string[0]. The reason to use this over .c_str() is that .c_str() returns a const char* but we cannot use const here.